### PR TITLE
repoUrl includes /owner/repo

### DIFF
--- a/responses/02.1_move-a-card.md
+++ b/responses/02.1_move-a-card.md
@@ -10,7 +10,7 @@ Add this issue to your new project board.
 
 ### :keyboard: Activity: Adding a project card
 
-1. Return to your [project]({{ repoUrl }}/{{ user.username }}/{{ repo }}/projects/1).
+1. Return to your [project]({{ repoUrl }}/projects/1).
 1. Above the project columns, click **Add cards**.
 1. Drag the **Organizing a release** card to your recently added "In Progress" column.
 


### PR DESCRIPTION
Followup to #118, this PR removes the extra `user.username` and `repo`, since they're included in `repoUrl`!