### PR TITLE
Move away from octokit for suggested changes

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -334,20 +334,10 @@ steps:
         number: "%actions.newPullRequest.data.number%"
         assignees: "%payload.repository.owner.login%"
       ## Suggest a change in the new PR
-      - type: octokit
-        method: pullRequests.createComment
-        owner: "%payload.repository.owner.login%"
-        repo: "%payload.repository.name%"
-        number: "%actions.newPullRequest.data.number%"
-        commit_id: "%actions.newPullRequest.data.head.sha%"
-        path: game.js
-        body: |
-          How's this change? 
-
-          ```suggestion
-              starCtx.fillStyle = "#000";
-          ```
-          For more information about suggest changes, check out this [GitHub Help](https://help.github.com/articles/incorporating-feedback-in-your-pull-request) article.
+      - type: createPullRequestComment
+        body: suggested-change.md
+        file: game.js
+        pullRequest: '%actions.newPullRequest.data.number%'
         position: 5
       - type: requestReviewFromRegistrant
         pullRequest: Accidental bugs

--- a/config.yml
+++ b/config.yml
@@ -334,7 +334,7 @@ steps:
         body: suggested-change.md
         file: game.js
         pullRequest: '%actions.newPullRequest.data.number%'
-        position: 5
+        position: 58
       - type: requestReviewFromRegistrant
         pullRequest: Accidental bugs
       - type: respond

--- a/config.yml
+++ b/config.yml
@@ -334,7 +334,7 @@ steps:
         body: suggested-change.md
         file: game.js
         pullRequest: '%actions.newPullRequest.data.number%'
-        position: 61
+        position: 5
       - type: requestReviewFromRegistrant
         pullRequest: Accidental bugs
       - type: respond

--- a/config.yml
+++ b/config.yml
@@ -334,7 +334,7 @@ steps:
         body: suggested-change.md
         file: game.js
         pullRequest: '%actions.newPullRequest.data.number%'
-        position: 58
+        position: 61
       - type: requestReviewFromRegistrant
         pullRequest: Accidental bugs
       - type: respond

--- a/responses/suggested-change.md
+++ b/responses/suggested-change.md
@@ -1,0 +1,6 @@
+How's this change? 
+
+```suggestion
+    starCtx.fillStyle = "#000";
+```
+For more information about suggest changes, check out this [GitHub Help](https://help.github.com/articles/incorporating-feedback-in-your-pull-request) article.


### PR DESCRIPTION
This PR uses the `createPullRequestComment` action instead of the octokit method to suggest a change. 

/cc @mattdavis0351 for 👀 