### PR TITLE
Update link to point to the project board

### DIFF
--- a/responses/14.1_congratulations.md
+++ b/responses/14.1_congratulations.md
@@ -8,7 +8,7 @@ Congratulations @{{ user.username }}, you've completed the **Creating a Release 
 
 - Created a release on GitHub based on a Git tag
 - Built an automated project board within your repository to manage your release
-    - If you look at the board now, everything has moved to the **Done** [column]({{ releases }})
+    - If you look at the [board]({{ projects }}/1) now, everything has moved to the **Done** column
 - Created and committed changes on a release branch
 - Created a hot fix branch to fix a bug on the release branch
 - Installed a Probot app to craft a changelog for your releases


### PR DESCRIPTION
The current link points to `column` with url to `release` .
I changed it to point to the `project board`.